### PR TITLE
update deps

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
 
   run:
     - python
-    - google-api-core >=1.16.0,<2.0.0dev
+    - google-api-core >=1.19.0,<2.0.0dev
 
 test:
   imports:


### PR DESCRIPTION
The anaconda recipe is missing a mandatory dep change from the conda-forge upstream for 1.4.1