### PR TITLE
Update 2.3.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - wheel
   run:
     - python
-    - google-api-core >=1.31.6,<3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0"
+    - google-api-core >=1.31.6,<3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0
     - google-auth >=1.25.0,<3.0.0dev
     - grpcio >=1.38.0,<2.0.0dev
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "google-cloud-core" %}
-{% set version = "2.2.2" %}
-{% set sha256 = "7d19bf8868b410d0bdf5a03468a3f3f2db233c0ee86a023f4ecc2b7a4b15f736" %}
+{% set version = "2.3.2" %}
+{% set sha256 = "b9529ee7047fd8d4bf4a2182de619154240df17fbe60ead399078c1ae152af9a" %}
 
 package:
   name: {{ name|lower }}
@@ -13,7 +13,7 @@ source:
 
 build:
   number: 0
-  noarch: python
+  skip: True #[py<37]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
@@ -23,10 +23,10 @@ requirements:
     - setuptools
     - wheel
   run:
-    - python >=3.6
-    - google-api-core >=1.21.0,<3.0.0dev
-    - google-auth >=1.24.0,<3.0.0dev
-    - grpcio >=1.8.2,<2.0.0dev
+    - python
+    - google-api-core >=1.31.6,<3.0.0dev
+    - google-auth >=1.25.0,<3.0.0dev
+    - grpcio >=1.38.0,<2.0.0dev
 
 test:
   imports:
@@ -51,7 +51,7 @@ about:
   summary: 'API Client library for Google Cloud: Core Helpers'
   description: This library is not meant to stand-alone. Instead it defines common helpers
     (e.g. base Client and Connection classes) used by all of the  google-cloud-*.
-  doc_url: https://googleapis.dev/python/google-cloud-core/latest/
+  doc_url: https://cloud.google.com/python/docs/reference/google-cloud-core/latest
   dev_url: https://github.com/googleapis/python-cloud-core
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,6 +48,7 @@ about:
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE
+  license_url: https://github.com/googleapis/python-cloud-core/blob/v2.3.2/LICENSE
   summary: 'API Client library for Google Cloud: Core Helpers'
   description: This library is not meant to stand-alone. Instead it defines common helpers
     (e.g. base Client and Connection classes) used by all of the  google-cloud-*.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - wheel
   run:
     - python
-    - google-api-core >=1.31.6,<3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0",
+    - google-api-core >=1.31.6,<3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0"
     - google-auth >=1.25.0,<3.0.0dev
     - grpcio >=1.38.0,<2.0.0dev
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - wheel
   run:
     - python
-    - google-api-core >=1.31.6,<3.0.0dev
+    - google-api-core >=1.31.6,<3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0",
     - google-auth >=1.25.0,<3.0.0dev
     - grpcio >=1.38.0,<2.0.0dev
 
@@ -39,16 +39,16 @@ test:
     - pip
   commands:
     - python -m pip check
-  downstreams:
-    - gensim
-    - google-cloud-storage
+#  downstreams:
+#    - gensim
+#    - google-cloud-storage
 
 about:
   home: https://github.com/googleapis/python-cloud-core
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE
-  license_url: https://github.com/googleapis/python-cloud-core/blob/v2.3.2/LICENSE
+  license_url: https://github.com/googleapis/python-cloud-core/blob/main/LICENSE
   summary: 'API Client library for Google Cloud: Core Helpers'
   description: This library is not meant to stand-alone. Instead it defines common helpers
     (e.g. base Client and Connection classes) used by all of the  google-cloud-*.


### PR DESCRIPTION
# Changes
---
- Bumped version
- Changed hash
- Removed noarch Python
- Skipping on anything below Python 3.7 (3.6 no longer supported)
- Updated dependencies
- Added license URL
- Changed Doc url though it is broken in the way it can't select specific versions so just pointing at latest for now.