### PR TITLE
google-cloud-core 2.5.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -69,7 +69,8 @@ about:
   license_family: Apache
   license_file: LICENSE
   summary: API Client library for Google Cloud Core Helpers
-  description: This library is not meant to stand-alone. Instead it defines common helpers
+  description: |
+    This library is not meant to stand-alone. Instead it defines common helpers
     (e.g. base Client and Connection classes) used by all of the  google-cloud-*.
   doc_url: https://cloud.google.com/python/docs/reference/google-cloud-core/latest
   dev_url: https://github.com/googleapis/python-cloud-core

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,20 +1,18 @@
 {% set name = "google-cloud-core" %}
-{% set version = "2.4.3" %}
+{% set version = "2.5.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace("-", "_")  }}-{{ version }}.tar.gz
-  sha256: 1fab62d7102844b278fe6dead3af32408b1df3eb06f5c7e8634cbd40edc4da53
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace("-", "_")  }}-{{ version }}.tar.gz
+  sha256: 7c1b7ef5c92311717bd05301aa1a91ffbc565673d3b0b4163a52d8413a186963
 
 build:
   number: 0
   skip: True  # [py<37]
-  skip: True  # [linux and s390x]
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv
 
 requirements:
   host:
@@ -24,24 +22,43 @@ requirements:
     - wheel
   run:
     - python
-    - google-api-core >=1.31.6,<3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0
-    - google-auth >=1.25.0,<3.0.0dev
-    - importlib-metadata>1.0.0  # [py<38]
+    - google-api-core >=1.31.6,<3.0.0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0
+    - google-auth >=1.25.0,<3.0.0
+    - importlib-metadata>1.0.0            # [py<38]
   run_constrained:
-    - grpcio >=1.38.0,<2.0.0dev
-    - grpcio-status >=1.38.0,<2.0.dev0
+    - grpcio >=1.38.0,<2.0.0              # [py<314]
+    - grpcio >=1.75.1,<2.0.0              # [py>=314]
+    - grpcio-status >=1.38.0,<2.0.0
 
 test:
+  source_files:
+    tests
   imports:
     - google.api_core.client_info
     - google.cloud.client
     - google.cloud.environment_vars
     - google.cloud.exceptions
     - google.cloud.operation
+    - google.auth
+    - google.cloud
+    - google.longrunning
+    - google.oauth2
+    - google.protobuf
+    - google.rpc
+    - google.type
   requires:
     - pip
+    - pytest
+    - google-api-core >=1.31.6,<3.0.0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0
+    - google-auth >=1.25.0,<3.0.0
+    - importlib-metadata>1.0.0            # [py<38]
+    - grpcio >=1.38.0,<2.0.0              # [py<314]
+    - grpcio >=1.75.1,<2.0.0              # [py>=314]
+    - grpcio-status >=1.38.0,<2.0.0
   commands:
     - python -m pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    - pytest -ra -vv tests
 #  downstreams:
 #    - gensim
 #    - google-cloud-storage
@@ -51,7 +68,7 @@ about:
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE
-  summary: 'API Client library for Google Cloud: Core Helpers'
+  summary: API Client library for Google Cloud Core Helpers
   description: This library is not meant to stand-alone. Instead it defines common helpers
     (e.g. base Client and Connection classes) used by all of the  google-cloud-*.
   doc_url: https://cloud.google.com/python/docs/reference/google-cloud-core/latest


### PR DESCRIPTION
google-cloud-core 2.5.0 

**Destination channel:** Defaults

### Links

- [PKG-10444]
- dev_url:        https://github.com/googleapis/python-cloud-core/tree/v2.5.0
- conda_forge:    https://github.com/conda-forge/google-cloud-core-feedstock
- pypi:           https://pypi.org/project/google-cloud-core/2.5.0
- pypi inspector: https://inspector.pypi.io/project/google-cloud-core/2.5.0

### Explanation of changes:

- new version number


[PKG-10444]: https://anaconda.atlassian.net/browse/PKG-10444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ